### PR TITLE
Cachebust join.js on the client side

### DIFF
--- a/lib/client/cloudcmd.js
+++ b/lib/client/cloudcmd.js
@@ -74,8 +74,9 @@ var CloudCmd;
     
     function createScript(url, callback) {
         var script      = document.createElement('script');
-        
-        script.src      = url;
+
+        // OSC_CUSTOM_CODE add .concat('?' + Date.now()) to the url to cachebust in the browser
+        script.src      = url.concat('?' + Date.now());
         script.async    = true;
         
         script.addEventListener('load', function load(event) {


### PR DESCRIPTION
@ericfranz 

This solves the `join.js` browser caching by giving the file a unique name on each load.

The filename is actually dynamic and this works without the question mark, but it just looks nicer and more familiar in devtools to see the separator.
