### PR TITLE
add help text above panel

### DIFF
--- a/css/ood_styles.css
+++ b/css/ood_styles.css
@@ -119,3 +119,22 @@ span.owner, span.mode {
 ul.files {
   width: 95%;
 }
+
+
+/* Help Text 
+ * position right above the panel
+ * the actual text is embeded inside the panel
+ *   * */
+.panel {
+  /* so we can absolutely position elements inside this panel*/
+  position: relative;
+}
+
+.panel h6.help {
+  /* position is in respect to panel*/
+  position: absolute;
+  top: -40px;
+  right: 0px;
+
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}

--- a/tmpl/fs/path.hbs
+++ b/tmpl/fs/path.hbs
@@ -1,4 +1,4 @@
 <!-- OSC_CUSTOM_CODE hide 'refresh' and 'clear clipboard' -->
 <!-- original <div data-name="js-path" class="reduce-text" title="{{ fullPath }}"><span data-name="js-clear-storage" class="path-icon icon-clear" title="clear clipboard (Ctrl+D)"></span><a data-name="js-refresh" href="{{ link }}" class="path-icon icon-refresh" title="refresh (Ctrl+R)"> </a><span data-name="js-links" class=links>{{ path }}</span></div> -->
 <div data-name="js-path" class="reduce-text" title="{{ fullPath }}"><span data-name="js-clear-storage"></span><a data-name="js-refresh" href="{{ link }}"></a><span data-name="js-links" class=links>{{ path }}</span></div>
-
+<h6 class="help">Right click to open a context menu to take actions with the selected file or folder.</h6>


### PR DESCRIPTION
add `<h6>` help text under panel section/div so that we can position
the text above the panel header

place this `<h6>` in the template that sets the header because this
is something that doesn't actively get replaced by javascript in a way
that another template in the panel would be messed with

by making the panel relatively positioned we can have the header element
absolutely positioned to the top corner of the panel, just outside of the
panel's edge
