### PR TITLE
disable attempts to select new file after delete

### DIFF
--- a/lib/client/dom.js
+++ b/lib/client/dom.js
@@ -1370,8 +1370,11 @@ var CloudCmd, Util, DOM, CloudFunc;
                         currentNew = next;
                     else if (prev)
                         currentNew = prev;
-                    
-                    DOM.setCurrentFile(currentNew);
+
+                    // OSC_CUSTOM_CODE there's an error when attempting to select a new file that causes a
+                    // file to appear to unsuccessfully delete. Here I just disable the autoselection of a new
+                    // file to prevent the error. See: https://github.com/AweSim-OSC/osc-fileexplorer/issues/61
+                    // DOM.setCurrentFile(currentNew);
                     
                     parent.removeChild(current);
                 }


### PR DESCRIPTION
fixes https://github.com/AweSim-OSC/osc-fileexplorer/issues/61

The client is attempting to select another file after delete but it isn't working (probably because the sibling has been deleted)

Removing the call to `setCurrentFile()` after delete fixes the error
