### PR TITLE
fixes AweSim-OSC/osc-fileexplorer/issues/59 deselection bug where file deselection is delayed

### DIFF
--- a/lib/client/dom.js
+++ b/lib/client/dom.js
@@ -883,6 +883,14 @@ var CloudCmd, Util, DOM, CloudFunc;
                 var current     = currentFile || this.getCurrentFile();
                     
                 current.classList.toggle(SELECTED_FILE);
+
+                // OSC_CUSTOM_CODE There is a bug where deselection is delayed, this is because the "selected-file"
+                // tag is successfully removed, but not the "current-file" tag. This removes the "current-file" tag
+                // if a file is deselected.
+                // https://github.com/AweSim-OSC/osc-fileexplorer/issues/59
+                if (current.classList.contains(CURRENT_FILE) && !current.classList.contains(SELECTED_FILE)){
+                    current.classList.remove(CURRENT_FILE);
+                }
                 
                 return Cmd;
             };


### PR DESCRIPTION
Fixes https://github.com/AweSim-OSC/osc-fileexplorer/issues/59

The app is appropriately removing the `.selected-file` class on deselect, but the `.current-file` class tag remains on the element until something else is clicked.

`.current-file` and `.selected-file` share the same css properties, so it appears to stay selected.

I've added a check after the toggle to remove `.current-file` if the file is no longer selected.
