### PR TITLE
sep styles: multiple selection and 'current file'

### DIFF
--- a/css/ood_styles.css
+++ b/css/ood_styles.css
@@ -8,27 +8,21 @@ div.fm ul.menu {
     background-color: white;
 }
 
-
-/* these styles control the selection style of a currently selected file */
-.current-file {
-    /*FIXME: background-color: rgb(0,75,135); - OH-TECH blue does look sharp */
-    background-color: #08C;
-}
-
-.current-file, .current-file a{
-    color: white;
-}
-
 .selected-file {
     /*FIXME: background-color: rgb(0,75,135); - OH-TECH blue does look sharp */
+    /* background-color: #08C; */
+    background-color: rgb(71,10,104);
+}
+
+/* these styles control the selection style of a currently selected file */
+.current-file, .current-file.selected-file {
+    /*FIXME: background-color: rgb(0,75,135); - OH-TECH blue does look sharp */
     background-color: #08C;
 }
 
-.selected-file, .selected-file .name > a {
-      color: white;
+.current-file, .current-file a, .selected-file, .selected-file .name > a{
+    color: white;
 }
-
-
 
 /* bootstrap-esque panel styling applied to cloud commander's panels
  * */


### PR DESCRIPTION
see https://github.com/AweSim-OSC/osc-fileexplorer/issues/67

original cloud commander used a subset of the context menu's actions for
the "current file" and others for "multiple selection"

until we support a special context menu for multiple selection, re-add
back this
