### PR TITLE
disable the right-click context menu

### DIFF
--- a/lib/client/listeners.js
+++ b/lib/client/listeners.js
@@ -18,7 +18,8 @@ var Util, DOM, CloudFunc, CloudCmd;
             };
         
         this.init = function () {
-            contextMenu();
+            // OSC_CUSTOM_CODE disable the context menu.
+            // contextMenu();
             dragndrop();
             unload();
             pop();


### PR DESCRIPTION
Now that buttons have been added to perform all of the desired funtionality of the right-click menu, the right-click menu is disabled here.

See https://github.com/AweSim-OSC/osc-fileexplorer/issues/47
