### PR TITLE
bug fixes to "next element" null errors

### DIFF
--- a/lib/client/dom.js
+++ b/lib/client/dom.js
@@ -1371,18 +1371,16 @@ var CloudCmd, Util, DOM, CloudFunc;
                 name        = Cmd.getCurrentName(current);
                 
                 if (current && name !== '..') {
-                    next    = current.nextSibling,
-                    prev    = current.previousSibling;
+                    // OSC_CUSTOM_CODE use (next|previous)ElementSibling instead of (next|previous)Sibling
+                    next    = current.nextElementSibling,
+                    prev    = current.previousElementSibling;
                         
                     if (next)
                         currentNew = next;
                     else if (prev)
                         currentNew = prev;
 
-                    // OSC_CUSTOM_CODE there's an error when attempting to select a new file that causes a
-                    // file to appear to unsuccessfully delete. Here I just disable the autoselection of a new
-                    // file to prevent the error. See: https://github.com/AweSim-OSC/osc-fileexplorer/issues/61
-                    // DOM.setCurrentFile(currentNew);
+                    DOM.setCurrentFile(currentNew);
                     
                     parent.removeChild(current);
                 }

--- a/lib/client/key.js
+++ b/lib/client/key.js
@@ -229,8 +229,11 @@ var CloudCmd, Util, DOM;
                 ctrlMeta        = ctrl || meta;
             
             if (current) {
-                prev            = current.previousSibling;
-                next            = current.nextSibling;
+                // OSC_CUSTOM_CODE this was using the incorrect method calls
+                // Updating these from fixes the arrow key functionality
+                // and probably any other bugs resulting from use of 'next' and 'prev'
+                prev            = current.previousElementSibling;
+                next            = current.nextElementSibling;
             }
             
             switch (keyCode) {

--- a/lib/client/key.js
+++ b/lib/client/key.js
@@ -430,12 +430,14 @@ var CloudCmd, Util, DOM;
             /* если нажали клавишу page down проматываем экран */
             case Key.PAGE_DOWN:
                 DOM.scrollByPages(panel, 1);
-                
+
                 for (i = 0; i < 30; i++) {
-                    if (!current.nextSibling)
+                    // OSC_CUSTOM_CODE use nextElementSibling instead of nextSibling
+                    if (!current.nextElementSibling)
                         break;
-                    
-                    current = current.nextSibling;
+
+                    // OSC_CUSTOM_CODE use nextElementSibling instead of nextSibling
+                    current = current.nextElementSibling;
                 }
                 
                 DOM.setCurrentFile(current);
@@ -447,10 +449,12 @@ var CloudCmd, Util, DOM;
                 DOM.scrollByPages(panel, -1);
                 
                 for (i = 0; i < 30; i++) {
-                    if (!current.previousSibling)
+                    // OSC_CUSTOM_CODE use previousElementSibling instead of previousSibling
+                    if (!current.previousElementSibling)
                         break;
-                    
-                    current = current.previousSibling;
+
+                    // OSC_CUSTOM_CODE use previousElementSibling instead of previousSibling
+                    current = current.previousElementSibling;
                 }
                 
                 DOM.setCurrentFile(current);


### PR DESCRIPTION
The base application is using the incorrect methods on the key bindings and so there are several bugs that occur as a result.

This PR adds arrow key functionality, page up/down funtionality, and provides a proper fix for https://github.com/AweSim-OSC/osc-fileexplorer/issues/61 where the app wasn't selecting the next file after a delete.
