### PR TITLE
fix multiselection bug where selection was off by one

### DIFF
--- a/lib/client/listeners.js
+++ b/lib/client/listeners.js
@@ -288,7 +288,8 @@ var Util, DOM, CloudFunc, CloudCmd;
         
         function getFilesRange(from, to) {
             var i           = 0,
-                delta       = 0,
+                // OSC_CUSTOM_CODE delta is incorrect here, switch from 0 to 1 since '..' is at index[0] in var files.
+                delta       = 1,
                 result      = [],
                 files       = DOM.getFiles(),
                 names       = DOM.getFilenames(files),


### PR DESCRIPTION
This resolves the error in the app where selecting a group of files selects one prior to the selection.

The delta was incorrect since `files[0]` always represents `".."` while `names[0]` filters it out.
