### PR TITLE
Disable commander view

### DIFF
--- a/css/ood_styles.css
+++ b/css/ood_styles.css
@@ -143,6 +143,7 @@ span.owner, span.mode {
     /* so we can absolutely position elements inside this panel*/
     position: relative;
     margin-top: 40px;
+    width: 100%;
 }
 
 .panel h6.help {

--- a/lib/client/dom.js
+++ b/lib/client/dom.js
@@ -270,10 +270,16 @@ var CloudCmd, Util, DOM, CloudFunc;
                 SelectType              = '*.*',
                 TITLE                   = 'Cloud Commander',
                 Title,
+                // OSC_CUSTOM_CODE only use the left panel
                 TabPanel   = {
-                    'js-left'        : null,
-                    'js-right'       : null
+                    'js-left'        : null
                 };
+                /* OSC_CUSTOM_CODE replaced this with the above
+                    TabPanel   = {
+                        'js-left'        : null,
+                        'js-right'       : null
+                    };
+                */
             
             /**
              * private function thet unset currentfile
@@ -1275,7 +1281,9 @@ var CloudCmd, Util, DOM, CloudFunc;
                  */
                 if (window.innerWidth < CloudCmd.MIN_ONE_PANEL_WIDTH)
                     panel = this.getByDataName('js-left');
-                    
+
+                // OSC_CUSTOM_CODE always use the left panel
+                panel       = this.getByDataName('js-left');
                 
                 if (!panel)
                     throw Error('can not find Active Panel!');

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -86,15 +86,17 @@
             side    : 'left',
             content : panel
         });
-        
-        right = rendy(Template.panel, {
-            side    : 'right',
-            content : panel
-        });
-        
+
+        /* OSC_CUSTOM_CODE don't render the right panel
+         right = rendy(Template.panel, {
+         side    : 'right',
+         content : panel
+         });
+         */
+
         data = rendy(data, {
             title   : CloudFunc.getTitle(),
-            fm      : left + right,
+            fm      : left, //  OSC_CUSTOM_CODE remove + right,
             prefix  : Prefix,
             css     : CSS_URL
         });


### PR DESCRIPTION
This PR removes the right panel completely.

It prevents the rendering of the right panel and modifies the javascript call that gets the active panel to always use the panel on the left.

Modification of the style also sets the width to 100%.
