### PR TITLE
show/hide dotfiles

### DIFF
--- a/css/ood_styles.css
+++ b/css/ood_styles.css
@@ -23,7 +23,6 @@ div.fm ul.menu {
     color: white;
 }
 
-
 .selected-file, .selected-file .name > a {
     color: white;
 }
@@ -161,6 +160,5 @@ span.owner, span.mode {
 
 .panel-btns {
     position: absolute;
-    top: -40px;
-    right: 0px;
+    right: 30px;
 }

--- a/html/index.html
+++ b/html/index.html
@@ -66,11 +66,16 @@
 
     // Update the css display tags on hidden files to hide or display
     function dotfiles() {
-        if (document.getElementById("checkbox-dotfiles").checked) {
+        if (isDotfilesChecked()) {
             jQuery12( ".files li.dotfile" ).css('display', '');
         } else {
             jQuery12( ".files li.dotfile" ).css('display', 'none');
         }
+    }
+
+    // Return state of dotfiles checkbox
+    function isDotfilesChecked() {
+        return document.getElementById("checkbox-dotfiles").checked;
     }
 
     // On page load, get the cookie and set the checkbox to the appropriate state
@@ -83,7 +88,7 @@
     // Sets the cookie when the dotfiles box is checked
     // then, call dotfiles() to update the css
     function dotfilesChecked() {
-        if (document.getElementById("checkbox-dotfiles").checked) {
+        if (isDotfilesChecked()) {
             setCookie('dotfiles', true, 9999);
         } else {
             setCookie('dotfiles', false, 9999);

--- a/html/index.html
+++ b/html/index.html
@@ -58,11 +58,13 @@
 <script>
     CloudCmd('{{ prefix }}');
 
+    // Launch the OSC terminal app in a new window
     function terminal() {
         var terminal_path = '/pun/sys/shell/ssh/oakley';
         window.open(terminal_path + DOM.getCurrentDirPath());
     }
 
+    // Update the css display tags on hidden files to hide or display
     function dotfiles() {
         if (document.getElementById("checkbox-dotfiles").checked) {
             $( ".files li.dotfile" ).css('display', '');
@@ -71,12 +73,15 @@
         }
     }
 
+    // On page load, get the cookie and set the checkbox to the appropriate state
+    // then, call dotfiles() to update the css
     window.onload = function() {
         document.getElementById("checkbox-dotfiles").checked = ( getCookie('dotfiles') === 'true' );
         dotfiles();
     };
 
     // Sets the cookie when the dotfiles box is checked
+    // then, call dotfiles() to update the css
     function dotfilesChecked() {
         if (document.getElementById("checkbox-dotfiles").checked) {
             setCookie('dotfiles', true, 9999);
@@ -86,6 +91,8 @@
         dotfiles();
     }
 
+    // OSC_CUSTOM_CODE getCookie and setCookie methods borrowed from
+    // http://www.w3schools.com/js/js_cookies.asp
     function setCookie(cname, cvalue, exdays) {
         var d = new Date();
         d.setTime(d.getTime() + (exdays*24*60*60*1000));
@@ -93,6 +100,8 @@
         document.cookie = cname + "=" + cvalue + "; " + expires;
     }
 
+    // OSC_CUSTOM_CODE getCookie and setCookie methods borrowed from
+    // http://www.w3schools.com/js/js_cookies.asp
     function getCookie(cname) {
         var name = cname + "=";
         var ca = document.cookie.split(';');

--- a/html/index.html
+++ b/html/index.html
@@ -67,9 +67,9 @@
     // Update the css display tags on hidden files to hide or display
     function dotfiles() {
         if (document.getElementById("checkbox-dotfiles").checked) {
-            $( ".files li.dotfile" ).css('display', '');
+            jQuery12( ".files li.dotfile" ).css('display', '');
         } else {
-            $( ".files li.dotfile" ).css('display', 'none');
+            jQuery12( ".files li.dotfile" ).css('display', 'none');
         }
     }
 

--- a/html/index.html
+++ b/html/index.html
@@ -96,10 +96,6 @@ if(typeof String.prototype.startsWith === "undefined"){
                 return document.getElementById("checkbox-dotfiles").checked;
             }
 
-            // On page load, get the cookie and set the checkbox to the appropriate state
-            // then, call dotfiles() to update the css
-
-
             // Sets the cookie when the dotfiles box is checked
             // then, call dotfiles() to update the css
             // since we're deleting the dotfiles when we hide them, we need to refresh when the user clicks

--- a/html/index.html
+++ b/html/index.html
@@ -69,11 +69,14 @@ if(typeof String.prototype.startsWith === "undefined"){
             // Event handler activates on page load
             jQuery12('body').on('panel_initialized', function(e){
                 initTree("{{ treeroot }}");
+                document.getElementById("checkbox-dotfiles").checked = ( getCookie('dotfiles') === 'true' );
+                dotfiles();
             });
 
             // Event handler activates after the panel update
             jQuery12('body').on('panel_dir_updated', function(e){
-
+                document.getElementById("checkbox-dotfiles").checked = ( getCookie('dotfiles') === 'true' );
+                dotfiles();
             });
 
             function terminal() {
@@ -83,10 +86,8 @@ if(typeof String.prototype.startsWith === "undefined"){
 
             // Update the css display tags on hidden files to hide or display
             function dotfiles() {
-                if (isDotfilesChecked()) {
-                    jQuery12( ".files li.dotfile" ).css('display', '');
-                } else {
-                    jQuery12( ".files li.dotfile" ).css('display', 'none');
+                if (!isDotfilesChecked()) {
+                    jQuery12( ".files li.dotfile" ).remove();
                 }
             }
 
@@ -97,16 +98,15 @@ if(typeof String.prototype.startsWith === "undefined"){
 
             // On page load, get the cookie and set the checkbox to the appropriate state
             // then, call dotfiles() to update the css
-            window.onload = function() {
-                document.getElementById("checkbox-dotfiles").checked = ( getCookie('dotfiles') === 'true' );
-                dotfiles();
-            };
+
 
             // Sets the cookie when the dotfiles box is checked
             // then, call dotfiles() to update the css
+            // since we're deleting the dotfiles when we hide them, we need to refresh when the user clicks
             function dotfilesChecked() {
                 if (isDotfilesChecked()) {
                     setCookie('dotfiles', true, 9999);
+                    CloudCmd.refresh();
                 } else {
                     setCookie('dotfiles', false, 9999);
                 }

--- a/html/index.html
+++ b/html/index.html
@@ -60,15 +60,21 @@ if(typeof String.prototype.startsWith === "undefined"){
         </div>
 
 <script src="{{ prefix }}/lib/client/ood_tree.js"></script>
-<script>
-jQuery12('body').on('panel_initialized', function(e){
-    initTree("{{ treeroot }}");
-});
-</script>
 
         <script src="{{ prefix }}/cloudcmd.js"></script>
         <script>
+
             CloudCmd('{{ prefix }}');
+
+            // Event handler activates on page load
+            jQuery12('body').on('panel_initialized', function(e){
+                initTree("{{ treeroot }}");
+            });
+
+            // Event handler activates after the panel update
+            jQuery12('body').on('panel_dir_updated', function(e){
+
+            });
 
             function terminal() {
                 var terminal_path = '/pun/sys/shell/ssh/oakley';
@@ -178,6 +184,6 @@ jQuery12('body').on('panel_initialized', function(e){
         </script>
 </head>
 
-    
+
 </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -1,90 +1,155 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <meta name="robots" content="noindex,nofollow">
-        <meta name="theme-color" content="rgb(49,123,249)">
-        <!-- mobile first design -->
-        <meta content="width=device-width,initial-scale=1" name="viewport">
-        <link rel="icon" href="{{ prefix }}/favicon.ico">
-        <title>{{ title }}</title>
-        
-        <link rel=stylesheet href="{{ prefix }}/css/urls.css">
-        <!-- OSC_CUSTOM_CODE add custom bootstrap stylesheet path -->
-        <link rel=stylesheet href="{{ prefix }}/css/ood_bootstrap.css">
-        <link rel=stylesheet href="{{ prefix }}/join:{{ css }}">
-        <noscript>
-            <link rel=stylesheet href="{{ prefix }}/css/nojs.css">
-        </noscript>
-    </head>
-    <body>
-        <div class=fm>{{ fm }}</div>
-        <div id="js-keyspanel" class="keyspanel">
-            <!-- OSC_CUSTOM_CODE remove this button >> <button id=f1      class="cmd-button reduce-text icon-help"      title="Help"            >F1</button> -->
-            <button id=f2      class="cmd-button reduce-text icon-rename"    title="Rename"          >F2</button>
-            <button id=f3      class="cmd-button reduce-text icon-view"      title="View"            >F3</button>
-            <button id=f4      class="cmd-button reduce-text icon-edit "     title="Edit"            >F4</button>
-            <button id=f5      class="cmd-button reduce-text icon-copy"      title="Copy"            >F5</button>
-            <button id=f6      class="cmd-button reduce-text icon-move"      title="Move"            >F6</button>
-            <button id=f7      class="cmd-button reduce-text icon-directory" title="New Directory"   >F7</button>
-            <button id=f8      class="cmd-button reduce-text icon-delete"    title="Delete"          >F8</button>
-            <button id=f9      class="cmd-button reduce-text icon-menu"      title="Menu"            >F9</button>
-            <button id=f10     class="cmd-button reduce-text icon-config"    title="Config"          >F10</button>
-            <!-- OSC_CUSTOM_CODE Convert console button to a link to wetty and remove the original defaults -->
-            <a onclick='window.open(CloudFunc.getWettyLink(CloudFunc.Path))' target="_blank"><button id=wetty       class="cmd-button reduce-text icon-console"   title="Wetty">~</button></a>
-            <!-- OSC_CUSTOM_CODE remove this button >> <button id=contact class="cmd-button reduce-text icon-contact"   title="Contact"         ></button> -->
-        </div>
-        <script src="{{ prefix }}/cloudcmd.js"></script>
-        <script>
-            CloudCmd('{{ prefix }}');
+<head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex,nofollow">
+    <meta name="theme-color" content="rgb(49,123,249)">
+    <!-- mobile first design -->
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <link rel="icon" href="{{ prefix }}/favicon.ico">
+    <title>{{ title }}</title>
 
-            function terminal() {
-                var terminal_path = '/pun/sys/shell/ssh/oakley';
-                window.open(terminal_path + DOM.getCurrentDirPath());
+    <link rel=stylesheet href="{{ prefix }}/css/urls.css">
+    <!-- OSC_CUSTOM_CODE add custom bootstrap stylesheet path -->
+    <link rel=stylesheet href="{{ prefix }}/css/ood_bootstrap.css">
+    <link rel=stylesheet href="{{ prefix }}/join:{{ css }}">
+    <noscript>
+        <link rel=stylesheet href="{{ prefix }}/css/nojs.css">
+    </noscript>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min.js"></script>
+    <script>
+        var jQuery12 = $.noConflict(true);
+        // replace this with shim: https://github.com/mathiasbynens/String.prototype.startsWith
+        // http://stackoverflow.com/questions/646628/how-to-check-if-a-string-startswith-another-string
+        if(typeof String.prototype.startsWith === "undefined"){
+            String.prototype.startsWith = function(str){
+                return this.indexOf(str, 0) === 0;
             }
+        }
+    </script>
+</head>
+<body>
+<div class="bootstrap panel-btns">
+    <button type="button" class="bootstrap icon icon-console btn btn-default btn-sm" onclick="terminal()">Open in Terminal</button>
+    <button type="button" class="bootstrap icon icon-paste btn btn-default btn-sm" onclick="DOM.Buffer.paste()">Paste</button>
+    <button type="button" class="bootstrap icon icon-file btn btn-default btn-sm" onclick="DOM.promptNewFile()">New File</button>
+    <button type="button" class="bootstrap icon icon-directory btn btn-default btn-sm" onclick="DOM.promptNewDir()">New Dir</button>
+    <button type="button" class="bootstrap icon icon-upload btn btn-default btn-sm" onclick="CloudCmd.Upload.show();">Upload</button>
+    <label class="bootstrap checkbox-inline"><input type="checkbox" class="bootstrap" id="checkbox-dotfiles" onclick="dotfilesChecked()" value="">Show Dotfiles</label>
+</div>
+<div class=fm>{{ fm }}</div>
+<div id="js-keyspanel" class="keyspanel">
+    <!-- OSC_CUSTOM_CODE remove this button >> <button id=f1      class="cmd-button reduce-text icon-help"      title="Help"            >F1</button> -->
+    <button id=f2      class="cmd-button reduce-text icon-rename"    title="Rename"          >F2</button>
+    <button id=f3      class="cmd-button reduce-text icon-view"      title="View"            >F3</button>
+    <button id=f4      class="cmd-button reduce-text icon-edit "     title="Edit"            >F4</button>
+    <button id=f5      class="cmd-button reduce-text icon-copy"      title="Copy"            >F5</button>
+    <button id=f6      class="cmd-button reduce-text icon-move"      title="Move"            >F6</button>
+    <button id=f7      class="cmd-button reduce-text icon-directory" title="New Directory"   >F7</button>
+    <button id=f8      class="cmd-button reduce-text icon-delete"    title="Delete"          >F8</button>
+    <button id=f9      class="cmd-button reduce-text icon-menu"      title="Menu"            >F9</button>
+    <button id=f10     class="cmd-button reduce-text icon-config"    title="Config"          >F10</button>
+    <!-- OSC_CUSTOM_CODE Convert console button to a link to wetty and remove the original defaults -->
+    <a onclick='window.open(CloudFunc.getWettyLink(CloudFunc.Path))' target="_blank"><button id=wetty       class="cmd-button reduce-text icon-console"   title="Wetty">~</button></a>
+    <!-- OSC_CUSTOM_CODE remove this button >> <button id=contact class="cmd-button reduce-text icon-contact"   title="Contact"         ></button> -->
+</div>
+<script src="{{ prefix }}/cloudcmd.js"></script>
+<script>
+    CloudCmd('{{ prefix }}');
 
-            // OSC_CUSTOM_CODE publicize download method from lib/client/menu.js
-            function download() {
-                var TIME        = 30 * 1000,
-                        prefixUr    = CloudCmd.PREFIX_URL,
-                        FS          = CloudFunc.FS,
-                        PACK        = '/pack',
-                        date        = Date.now(),
-                        files       = DOM.getActiveFiles();
+    function terminal() {
+        var terminal_path = '/pun/sys/shell/ssh/oakley';
+        window.open(terminal_path + DOM.getCurrentDirPath());
+    }
 
-                if (!files.length)
-                    DOM.Dialog.alert.noFiles();
+    function dotfiles() {
+        if (document.getElementById("checkbox-dotfiles").checked) {
+            $( ".files li.dotfile" ).css('display', '');
+        } else {
+            $( ".files li.dotfile" ).css('display', 'none');
+        }
+    }
+
+    window.onload = function() {
+        document.getElementById("checkbox-dotfiles").checked = ( getCookie('dotfiles') === 'true' );
+        dotfiles();
+    };
+
+    // Sets the cookie when the dotfiles box is checked
+    function dotfilesChecked() {
+        if (document.getElementById("checkbox-dotfiles").checked) {
+            setCookie('dotfiles', true, 9999);
+        } else {
+            setCookie('dotfiles', false, 9999);
+        }
+        dotfiles();
+    }
+
+    function setCookie(cname, cvalue, exdays) {
+        var d = new Date();
+        d.setTime(d.getTime() + (exdays*24*60*60*1000));
+        var expires = "expires="+d.toUTCString();
+        document.cookie = cname + "=" + cvalue + "; " + expires;
+    }
+
+    function getCookie(cname) {
+        var name = cname + "=";
+        var ca = document.cookie.split(';');
+        for(var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) == 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return "";
+    }
+
+    // OSC_CUSTOM_CODE publicize download method from lib/client/menu.js
+    function download() {
+        var TIME        = 30 * 1000,
+                prefixUr    = CloudCmd.PREFIX_URL,
+                FS          = CloudFunc.FS,
+                PACK        = '/pack',
+                date        = Date.now(),
+                files       = DOM.getActiveFiles();
+
+        if (!files.length)
+            DOM.Dialog.alert.noFiles();
+        else
+            files.forEach(function(file) {
+                var element,
+                        selected    = DOM.isSelected(file),
+                        path        = DOM.getCurrentPath(file),
+                        id          = DOM.load.getIdBySrc(path),
+                        isDir       = DOM.isCurrentIsDir(file);
+
+                CloudCmd.log('downloading file ' + path + '...');
+
+                if (isDir)
+                    path        = prefixUr + PACK + path + '.tar.gz';
                 else
-                    files.forEach(function(file) {
-                        var element,
-                                selected    = DOM.isSelected(file),
-                                path        = DOM.getCurrentPath(file),
-                                id          = DOM.load.getIdBySrc(path),
-                                isDir       = DOM.isCurrentIsDir(file);
+                    path        = prefixUr + FS + path + '?download';
 
-                        CloudCmd.log('downloading file ' + path + '...');
+                element     = DOM.load({
+                    id          : id + '-' + date,
+                    name        : 'iframe',
+                    async       : false,
+                    className   : 'hidden',
+                    src         : path
+                });
 
-                        if (isDir)
-                            path        = prefixUr + PACK + path + '.tar.gz';
-                        else
-                            path        = prefixUr + FS + path + '?download';
+                setTimeout(function() {
+                    document.body.removeChild(element);
+                }, TIME);
 
-                        element     = DOM.load({
-                            id          : id + '-' + date,
-                            name        : 'iframe',
-                            async       : false,
-                            className   : 'hidden',
-                            src         : path
-                        });
-
-                        setTimeout(function() {
-                            document.body.removeChild(element);
-                        }, TIME);
-
-                        if (selected)
-                            DOM.toggleSelectedFile(file);
-                    });
-            }
-        </script>
-    </body>
+                if (selected)
+                    DOM.toggleSelectedFile(file);
+            });
+    }
+</script>
+</body>
 </html>

--- a/lib/cloudfunc.js
+++ b/lib/cloudfunc.js
@@ -1,8 +1,8 @@
 (function(global) {
     'use strict';
-    
+
     var rendy;
-    
+
     if (typeof module === 'object' && module.exports) {
         rendy               = require('rendy');
         module.exports      = new CloudFuncProto();
@@ -10,77 +10,77 @@
         rendy               = window.rendy;
         global.CloudFunc    = new CloudFuncProto();
     }
-    
+
     function CloudFuncProto() {
         var CloudFunc               = this,
             Entity                  = new entityProto(),
             FS;
-        
+
         /* КОНСТАНТЫ (общие для клиента и сервера)*/
-        
+
         /* название программы */
         this.NAME                   = 'Cloud Commander';
-        
+
         /* если в ссылке будет эта строка - в браузере js отключен */
         this.FS    =   FS           = '/fs';
-        
+
         this.apiURL                 = '/api/v1';
         this.MAX_FILE_SIZE          = 500 * 1024;
         this.Entity                 = Entity;
-        
+
         function entityProto() {
             var Entities = {
                 '&nbsp;': ' ',
                 '&lt;'  : '<',
                 '&gt;'   : '>'
             };
-            
+
             this.encode = function(str) {
                 Object.keys(Entities).forEach(function(code) {
                     var char    = Entities[code],
                         reg     = RegExp(char, 'g');
-                    
+
                     str = str.replace(reg, code);
                 });
-                
+
                 return str;
             };
-            
+
             this.decode = function(str) {
                 Object.keys(Entities).forEach(function(code) {
                     var char    = Entities[code],
                         reg     = RegExp(code, 'g');
-                    
+
                     str = str.replace(reg, char);
                 });
-                
+
                 return str;
             };
         }
-        
+
         this.formatMsg              = function(msg, name, status) {
             if (!status)
                 status = 'ok';
-            
+
             if (name)
                 name = '("' + name + '")';
             else
                 name = '';
-            
+
             msg = msg + ': ' + status + name;
-            
+
             return msg;
         };
-        
+
         /** Функция возвращает заголовок веб страницы
          * @pPath
          */
         this.getTitle               = function(pPath) {
             if (!CloudFunc.Path)
                 CloudFunc.Path = '/';
-                
+
             return  CloudFunc.NAME + ' - ' + (pPath || CloudFunc.Path);
-                
+
         };
 
         /**
@@ -91,7 +91,7 @@
             var shell = "/pun/sys/shell";
             return  shell + "/ssh/default" + pPath;
         }
-        
+
         /** Функция получает адреса каждого каталога в пути
          * возвращаеться массив каталогов
          * @param url -  адрес каталога
@@ -100,33 +100,33 @@
             var namesRaw, names, length,
                 pathHTML    = '',
                 path        = '/';
-            
+
             if (!url)
                 throw Error('url could not be empty!');
-            
+
             if (!template)
                 throw Error('template could not be empty!');
-            
+
             namesRaw    = url.split('/')
-                             .slice(1, -1),
-            
-            names       = [].concat('/', namesRaw),
-            
-            length      = names.length - 1;
-            
+                .slice(1, -1),
+
+                names       = [].concat('/', namesRaw),
+
+                length      = names.length - 1;
+
             names.forEach(function(name, index) {
                 var slash       = '',
                     isLast      = index === length;
-                
+
                 if (index)
                     path        += name + '/';
-                
+
                 if (index && isLast) {
                     pathHTML    += name + '/';
                 } else {
                     if (index)
                         slash = '/';
-                    
+
                     pathHTML    += rendy(template, {
                         path: path,
                         name: name,
@@ -135,7 +135,7 @@
                     });
                 }
             });
-            
+
             return pathHTML;
         }
 
@@ -152,7 +152,7 @@
             }
             return prettyDate;
         }
-        
+
         /**
          * Функция строит таблицу файлв из JSON-информации о файлах
          * @param params - информация о файлах
@@ -169,20 +169,20 @@
                 json            = params.data,
                 files           = json.files,
                 path            = json.path,
-                
-                /*
-                 * Строим путь каталога в котором мы находимся
-                 * со всеми подкаталогами
-                 */
+
+            /*
+             * Строим путь каталога в котором мы находимся
+             * со всеми подкаталогами
+             */
                 htmlPath        = getPathLink(path, prefix, template.pathLink),
-                
+
                 fileTable       = rendy(template.path, {
                     link        : prefix + FS + path,
                     fullPath    : path,
                     path        : htmlPath
                 }),
 
-                // OSC_CUSTOM_CODE change 'date' to 'modified date'
+            // OSC_CUSTOM_CODE change 'date' to 'modified date'
                 header         = rendy(templateFile, {
                     tag         : 'div',
                     attribute   : '',
@@ -194,12 +194,12 @@
                     owner       : 'owner',
                     mode        : 'mode'
                 });
-            
+
             fileTable          += header;
-            
+
             /* сохраняем путь */
             CloudFunc.Path      = path;
-            
+
             fileTable           += '<ul data-name="js-files" class="files">';
             /* Если мы не в корне */
             if (path !== '/') {
@@ -209,43 +209,39 @@
                 /* Если предыдущий каталог корневой */
                 if (dotDot === '')
                     dotDot = '/';
-                
+
                 link            = prefix + FS + dotDot;
-                
+
                 linkResult      = rendy(template.link, {
                     link        : link,
                     title       : '..',
                     name        : '..'
                 });
-                
+
                 dataName        = 'data-name="js-file-.." ',
-                attribute       = 'draggable="true" ' + dataName,
-                /* Сохраняем путь к каталогу верхнего уровня
-                * OSC_CUSTOM_CODE use blank date instead of '--.--.----'
-                * */
-                fileTable += rendy(template.file, {
-                    tag         : 'li',
-                    attribute   : attribute,
-                    className   : '',
-                    type        : 'directory',
-                    name        : linkResult,
-                    size        : '&lt;dir&gt;',
-                    date        : '          ',
-                    owner       : '.',
-                    mode        : '--- --- ---'
-                });
+                    attribute       = 'draggable="true" ' + dataName,
+                    /* Сохраняем путь к каталогу верхнего уровня
+                     * OSC_CUSTOM_CODE use blank date instead of '--.--.----'
+                     * */
+                    fileTable += rendy(template.file, {
+                        tag         : 'li',
+                        attribute   : attribute,
+                        className   : '',
+                        type        : 'directory',
+                        name        : linkResult,
+                        size        : '&lt;dir&gt;',
+                        date        : '          ',
+                        owner       : '.',
+                        mode        : '--- --- ---'
+                    });
             }
 
-            // OSC_CUSTOM_CODE hide all dot files
-            files = files.filter(function(value) {
-                return value.name.charAt(0) !== '.';
-            });
-            
             n = files.length;
             for (i = 0; i < n; i++) {
                 file            = files[i];
                 link            = prefix + FS + path + file.name;
-                
+                var isDotfile   = file.name.charAt(0) === "."; // OSC_CUSTOM_CODE add var, true if file starts with '.'
+
                 if (file.size === 'dir') {
                     type        = 'directory';
                     attribute   = '';
@@ -260,21 +256,21 @@
                 date    = buildPrettyDate(file.date) || '          ';
                 owner   = file.owner || 'root';
                 mode    = file.mode;
-                
+
                 linkResult  = rendy(templateLink, {
                     link        : link,
                     title       : file.name,
                     name        : Entity.encode(file.name),
                     attribute   : attribute
                 });
-                
+
                 dataName        = 'data-name="js-file-' + file.name + '" ';
                 attribute       = 'draggable="true" ' + dataName;
-                
+
                 fileTable += rendy(templateFile, {
                     tag         : 'li',
                     attribute   : attribute,
-                    className   : '',
+                    className   : isDotfile ? 'dotfile' : '',  // OSC_CUSTOM_CODE add dotfiles class to dotfiles
                     /* Если папка - выводим пиктограмму папки   *
                      * В противоположном случае - файла         */
                     type        : type,
@@ -285,10 +281,10 @@
                     mode        : mode
                 });
             }
-            
+
             fileTable          += '</ul>';
-            
+
             return fileTable;
         };
-     }
+    }
 })(this);

--- a/tmpl/fs/path.hbs
+++ b/tmpl/fs/path.hbs
@@ -10,11 +10,4 @@
     <button type="button" class="icon icon-copy btn btn-default btn-sm" onclick="DOM.Buffer.copy()">Copy</button>
     <button type="button" class="icon icon-unselect-all btn btn-default btn-sm" onclick="DOM.toggleAllSelectedFiles()">(Un)Select All</button>
     <button type="button" class="icon icon-delete btn btn-danger btn-sm pull-right" onclick="CloudCmd.Operation.show('delete');">Delete</button>
-    <div class="panel-btns">
-        <button type="button" class="icon icon-console btn btn-default btn-sm" onclick="terminal()">Open in Terminal</button>
-        <button type="button" class="icon icon-paste btn btn-default btn-sm" onclick="DOM.Buffer.paste()">Paste</button>
-        <button type="button" class="icon icon-file btn btn-default btn-sm" onclick="DOM.promptNewFile()">New File</button>
-        <button type="button" class="icon icon-directory btn btn-default btn-sm" onclick="DOM.promptNewDir()">New Dir</button>
-        <button type="button" class="icon icon-upload btn btn-default btn-sm" onclick="CloudCmd.Upload.show();">Upload</button>
-    </div>
 </div>


### PR DESCRIPTION
This works by setting a cookie on the checkbox state change and then if the "Show dotfiles" box is unchecked, the app deletes the elements marked with the `dotfile` class.

By deleting the elements instead of hiding them we don't break the arrow/pgup/pgdn/selection stuff.
