### PR TITLE
Make editor and shell url prefixes set by config in app.js

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -52,7 +52,7 @@
         initTree("{{ treeroot }}");
     });
     OSC = {
-        editor: "{{ file_editor }}",
+        file_editor: "{{ file_editor }}",
         shell: "{{ shell }}"
     };
 </script>

--- a/html/index.html
+++ b/html/index.html
@@ -51,7 +51,7 @@
     jQuery12('body').on('panel_initialized', function(e){
         initTree("{{ treeroot }}");
     });
-    OSC = {
+    OOD = {
         file_editor: "{{ file_editor }}",
         shell: "{{ shell }}"
     };

--- a/html/index.html
+++ b/html/index.html
@@ -67,6 +67,10 @@
     jQuery12('body').on('panel_initialized', function(e){
         initTree("{{ treeroot }}");
     });
+    OSC = {
+        editor: "{{ file_editor }}",
+        shell: "{{ shell }}"
+    };
 </script>
 
 </body>

--- a/html/index.html
+++ b/html/index.html
@@ -44,22 +44,6 @@
         <label class="bootstrap checkbox-inline"><input type="checkbox" class="bootstrap" id="checkbox-ownermode" onclick="ownerModeChecked()" value="">Show Owner/Mode</label>
     </div>
     <div class="fm">{{ fm }}</div>
-    <div id="js-keyspanel" class="keyspanel">
-        <!-- OSC_CUSTOM_CODE remove this button >> <button id=f1      class="cmd-button reduce-text icon-help"      title="Help"            >F1</button> -->
-        <button id=f2      class="cmd-button reduce-text icon-rename"    title="Rename"          >F2</button>
-        <button id=f3      class="cmd-button reduce-text icon-view"      title="View"            >F3</button>
-        <button id=f4      class="cmd-button reduce-text icon-edit "     title="Edit"            >F4</button>
-        <button id=f5      class="cmd-button reduce-text icon-copy"      title="Copy"            >F5</button>
-        <button id=f6      class="cmd-button reduce-text icon-move"      title="Move"            >F6</button>
-        <button id=f7      class="cmd-button reduce-text icon-directory" title="New Directory"   >F7</button>
-        <button id=f8      class="cmd-button reduce-text icon-delete"    title="Delete"          >F8</button>
-        <button id=f9      class="cmd-button reduce-text icon-menu"      title="Menu"            >F9</button>
-        <button id=f10     class="cmd-button reduce-text icon-config"    title="Config"          >F10</button>
-        <!-- OSC_CUSTOM_CODE Convert console button to a link to wetty and remove the original defaults -->
-        <a onclick='window.open(CloudFunc.getWettyLink(CloudFunc.Path))' target="_blank"><button id=wetty       class="cmd-button reduce-text icon-console"   title="Wetty">~</button></a>
-        <!-- OSC_CUSTOM_CODE remove this button >> <button id=contact class="cmd-button reduce-text icon-contact"   title="Contact"         ></button> -->
-    </div>
-
 <script src="{{ prefix }}/lib/client/ood_tree.js"></script>
 <script src="{{ prefix }}/lib/client/ood.js"></script>
 <script>

--- a/lib/client/menu.js
+++ b/lib/client/menu.js
@@ -144,11 +144,9 @@ var CloudCmd, Util, DOM, CloudFunc, MenuIO;
         
         function getMenuData(isAuth) {
             var menu = {
-                // OSC_CUSTOM_CODE add the function to open the path in the terminal to the menu
                 'Open Path In Terminal'
                     : function () {
-                    var terminal_path = '/pun/sys/shell/ssh/oakley';
-                    window.open(terminal_path + DOM.getCurrentDirPath());
+                    console.log("not implemented");
                 },
                 'Paste'         : Buffer.paste,
                 'New'           : {

--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -20,10 +20,10 @@ function currentPathIsDirectory(){
     return DOM.getCurrentSize() == "dir";
 }
 
-// display the osc terminal in a new window
+// display the ood terminal in a new window
 function terminal() {
-    if(OSC.shell != null && OSC.shell != ""){
-      window.open(OSC.shell + DOM.getCurrentPath());
+    if(OOD.shell != null && OOD.shell != ""){
+      window.open(OOD.shell + DOM.getCurrentPath());
     }
     else{
       console.log("shell url prefix is not set in config in app.js");
@@ -35,8 +35,8 @@ function ood_editor(){
         DOM.Dialog.alert("File Explorer", "Please select a file to edit");
     }
     else{
-        if(OSC.file_editor != null && OSC.file_editor != ""){
-          window.open(OSC.file_editor + DOM.getCurrentPath());
+        if(OOD.file_editor != null && OOD.file_editor != ""){
+          window.open(OOD.file_editor + DOM.getCurrentPath());
         }
         else{
           console.log("file_editor url prefix is not set in config in app.js");

--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -23,7 +23,7 @@ function currentPathIsDirectory(){
 // display the ood terminal in a new window
 function terminal() {
     if(OOD.shell != null && OOD.shell != ""){
-      window.open(OOD.shell + DOM.getCurrentPath());
+      window.open(OOD.shell + DOM.getCurrentDirPath());
     }
     else{
       console.log("shell url prefix is not set in config in app.js");

--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -22,8 +22,12 @@ function currentPathIsDirectory(){
 
 // display the osc terminal in a new window
 function terminal() {
-    var terminal_path = '/pun/sys/shell/ssh/oakley';
-    window.open(terminal_path + DOM.getCurrentDirPath());
+    if(OSC.shell != null && OSC.shell != ""){
+      window.open(OSC.shell + DOM.getCurrentPath());
+    }
+    else{
+      console.log("shell url prefix is not set in config in app.js");
+    }
 }
 
 function ood_editor(){
@@ -31,8 +35,12 @@ function ood_editor(){
         DOM.Dialog.alert("File Explorer", "Please select a file to edit");
     }
     else{
-        var editor_path = '/pun/dev/osc-editor/edit';
-        window.open(editor_path + DOM.getCurrentPath());
+        if(OSC.file_editor != null && OSC.file_editor != ""){
+          window.open(OSC.file_editor + DOM.getCurrentPath());
+        }
+        else{
+          console.log("file_editor url prefix is not set in config in app.js");
+        }
     }
 }
 

--- a/lib/cloudfunc.js
+++ b/lib/cloudfunc.js
@@ -83,15 +83,6 @@
 
         };
 
-        /**
-         * OSC_CUSTOM_CODE add a function to build a wetty link from the current DOM path
-         * FIXME: this will need to be updated when we get a stable app location
-         */
-        this.getWettyLink           = function(pPath) {
-            var shell = "/pun/sys/shell";
-            return  shell + "/ssh/default" + pPath;
-        }
-
         /** Функция получает адреса каждого каталога в пути
          * возвращаеться массив каталогов
          * @param url -  адрес каталога

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -101,7 +101,9 @@
             fm      : left, //  OSC_CUSTOM_CODE remove + right,
             prefix  : Prefix,
             css     : CSS_URL,
-            treeroot    : config("treeroot") || HOME
+            treeroot    : config("treeroot") || HOME,
+            file_editor  : config("file_editor") || "",
+            shell   : config("shell") || ""
         });
         
         return data;


### PR DESCRIPTION
Changes provided ensure that you set the prefixes in app.js i.e.

```
file_editor: "/pun/dev/osc-editor/edit",
shell: "/pun/sys/shell/ssh/default"
```

Fixes https://github.com/AweSim-OSC/osc-fileexplorer/issues/81
