### PR TITLE
update download path to use custom folder route for zipfiles

### DIFF
--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -133,7 +133,7 @@ function download() {
             CloudCmd.log('downloading file ' + path + '...');
 
             if (isDir)
-                path        = prefixUr + PACK + path + '.tar.gz';
+                path	    = CloudCmd.PREFIX + '/oodzip' + path;
             else
                 path        = prefixUr + FS + path + '?download';
 


### PR DESCRIPTION
rather than using the /pack api, we have a middleware in osc-filexplorer at https://github.com/AweSim-OSC/osc-fileexplorer/pull/102

This updates the download button to use that path.
