### PR TITLE
Show edit and terminal buttons only if configured.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -36,7 +36,7 @@
 <body class="hide-owner-mode">
     <div class="bootstrap panel-btns">
         <button type="button" class="bootstrap icon icon-directory btn btn-default btn-sm" onclick="DOM.goToDirectory()">Go To...</button>
-        <button type="button" class="bootstrap icon icon-console btn btn-default btn-sm" onclick="terminal()">Open in Terminal</button>
+        <button type="button" class="bootstrap icon icon-console btn btn-default btn-sm hidden" id="terminal-button" onclick="terminal()">Open in Terminal</button>
         <button type="button" class="bootstrap icon icon-new btn btn-default btn-sm" onclick="DOM.promptNewFile()">New File</button>
         <button type="button" class="bootstrap icon icon-directory btn btn-default btn-sm" onclick="DOM.promptNewDir()">New Dir</button>
         <button type="button" class="bootstrap icon icon-upload btn btn-default btn-sm" onclick="CloudCmd.Upload.show();">Upload</button>

--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -5,6 +5,15 @@ jQuery12('body').on('panel_initialized', function(e){
     dotfiles();
     document.getElementById("checkbox-ownermode").checked = ( getCookie('ownermode') === 'true' );
     ownerMode();
+
+    // If the shell is available, show the button.
+    if(OOD.shell != null && OOD.shell != ""){
+        document.getElementById("terminal-button").classList.remove("hidden");
+    }
+    // If the file-editor is available, show the button.
+    if(OOD.file_editor != null && OOD.file_editor != ""){
+        document.getElementById("editor-button").classList.remove("hidden");
+    }
 });
 
 // Event handler activates after the panel update
@@ -26,7 +35,7 @@ function terminal() {
       window.open(OOD.shell + DOM.getCurrentDirPath());
     }
     else{
-      console.log("shell url prefix is not set in config in app.js");
+      console.log("shell url prefix is not set. See osc-fileexplorer README to configure environment variables.");
     }
 }
 
@@ -39,7 +48,7 @@ function ood_editor(){
           window.open(OOD.file_editor + DOM.getCurrentPath());
         }
         else{
-          console.log("file_editor url prefix is not set in config in app.js");
+          console.log("file_editor url prefix is not set. See osc-fileexplorer README to configure environment variables.");
         }
     }
 }

--- a/tmpl/fs/path.hbs
+++ b/tmpl/fs/path.hbs
@@ -4,7 +4,7 @@
 <!-- <h6 class="help">Right click to open a context menu to take actions with the selected file or folder.</h6> -->
 <div class="menu-buttons bootstrap">
     <button type="button" class="icon icon-view btn btn-default btn-sm" onclick="CloudCmd['View'].show()">View</button>
-    <button type="button" class="icon icon-edit btn btn-default btn-sm" onclick="ood_editor()">Edit</button>
+    <button type="button" class="icon icon-edit btn btn-default btn-sm hidden" id="editor-button" onclick="ood_editor()">Edit</button>
     <button type="button" class="icon icon-rename btn btn-default btn-sm" onclick="DOM.renameCurrent()">Rename</button>
     <button type="button" class="icon icon-download btn btn-primary btn-sm" onclick="download()">Download</button>
     <button type="button" class="icon icon-copy btn btn-default btn-sm" data-toggle="tooltip"


### PR DESCRIPTION
It seemed better to hide the buttons by default and show them if the associated apps were available, otherwise they were appearing on the screen and then disappearing after the check in the onload method. 
