### PR TITLE
fix chrome warning for deprecated js method

### DIFF
--- a/lib/client/key.js
+++ b/lib/client/key.js
@@ -108,15 +108,18 @@ var CloudCmd, Util, DOM;
                 ctrl            = event.ctrlKey,
                 shift           = event.shiftKey,
                 meta            = event.metaKey,
-                keyIdentifier   = event.keyIdentifier,
                 isBetween       = keyCode >= KEY.ZERO && keyCode <= KEY.Z,
                 isSymbol,
                 char            = '';
 
-            if (keyIdentifier)
-                char = fromCharCode(keyIdentifier);
-            else
+            /*
+             * event.keyIdentifier deprecated in chrome v51
+             * but event.key is absent in chrome <= v51
+             */
+            if (event.key)
                 char = event.key;
+            else
+                char = fromCharCode(event.keyIdentifier);
 
             isSymbol = ~['.', '_', '-', '+', '='].indexOf(char);
 


### PR DESCRIPTION
Fixes a warning. `event.keyIdentifier` will be removed in the next version of chrome later this month.

It looks like there was already handling around it, but this removes the warning and will prevent issues when the latest chrome arrives.
