### PR TITLE
downloading to system route

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -53,7 +53,8 @@
     });
     OOD = {
         file_editor: "{{ file_editor }}",
-        shell: "{{ shell }}"
+        shell: "{{ shell }}",
+        ood_download: "{{ ood_download }}"
     };
 </script>
 <script src="{{ prefix }}/cloudcmd.js"></script>

--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -156,7 +156,13 @@ function download() {
             else
                 // Workaround for large files filling up /tmp folder
                 // uses a custom nginx route configured at /pun/download
-                path        = '/pun/download' + path + '?download';
+                if (ood_download) {
+                    path        = '/pun/download' + path + '?download=' + Date.now();
+                } else {
+                    path        = prefixUr + FS + path + '?download';
+                }
+
+
 
             element     = DOM.load({
                 id          : id + '-' + date,

--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -153,7 +153,7 @@ function download() {
 
             if (isDir)
                 path	    = CloudCmd.PREFIX + '/oodzip' + path;
-            else
+            else {
                 // Workaround for large files filling up /tmp folder
                 // uses a custom nginx route configured at /pun/download
                 if (ood_download) {
@@ -161,8 +161,7 @@ function download() {
                 } else {
                     path        = prefixUr + FS + path + '?download';
                 }
-
-
+            }
 
             element     = DOM.load({
                 id          : id + '-' + date,

--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -154,7 +154,9 @@ function download() {
             if (isDir)
                 path	    = CloudCmd.PREFIX + '/oodzip' + path;
             else
-                path        = prefixUr + FS + path + '?download';
+                // Workaround for large files filling up /tmp folder
+                // uses a custom nginx route configured at /pun/download
+                path        = '/pun/download' + path + '?download';
 
             element     = DOM.load({
                 id          : id + '-' + date,

--- a/lib/client/ood.js
+++ b/lib/client/ood.js
@@ -156,7 +156,7 @@ function download() {
             else {
                 // Workaround for large files filling up /tmp folder
                 // uses a custom nginx route configured at /pun/download
-                if (ood_download) {
+                if (OOD.ood_download) {
                     path        = '/pun/download' + path + '?download=' + Date.now();
                 } else {
                     path        = prefixUr + FS + path + '?download';

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -1,6 +1,6 @@
 (function() {
     'use strict';
-    
+
     var DIR         = __dirname + '/../../',
         DIR_TMPL    = DIR       + 'tmpl/',
         DIR_HTML    = DIR       + 'html/',
@@ -8,25 +8,25 @@
         DIR_JSON    = DIR       + 'json/',
         DIR_SERVER  = __dirname + '/',
         DIR_FS      = DIR_TMPL  + 'fs/',
-        
+
         fs          = require('fs'),
-        
+
         flop        = require('flop'),
         ponse       = require('ponse'),
         files       = require('files-io'),
         rendy       = require('rendy'),
         exec        = require('execon'),
-        
+
         minify      = require('minify'),
         format      = require('format-io'),
-        
+
         config      = require(DIR_SERVER + 'config'),
         root        = require(DIR_SERVER + 'root'),
-        
+
         CloudFunc   = require(DIR_LIB + 'cloudfunc'),
         HOME        = require('os-homedir')(),
         PATH_INDEX  = DIR_HTML   + 'index.html',
-        
+
         TMPL_PATH   = [
             'file',
             'panel',
@@ -34,11 +34,11 @@
             'pathLink',
             'link'
         ],
-        
+
         Template    = {},
-        
+
         Prefix,
-        
+
         FS          = CloudFunc.FS,
 
         // OSC_CUSTOM_CODE add + "?" + Date.now() to prevent browser caching of css files
@@ -46,21 +46,21 @@
                         .map(function(name) {
                             return 'css/' + name + '.css';
                         }).join(':') + "?" + Date.now();
-    
+
     module.exports  = function(params) {
         var p = params || {};
-        
+
         Prefix = p.prefix || '';
-        
+
         return middle;
     };
-    
+
     function middle(req, res, next) {
         readFiles(function() {
             route(req, res, next);
         });
     }
-    
+
     /**
      * additional processing of index file
      */
@@ -69,19 +69,19 @@
             keysPanel   = '<div id="js-keyspanel" class="{{ className }}',
             data        = options.data,
             panel       = options.panel;
-        
+
         if (!config('showKeysPanel')) {
             from        = rendy(keysPanel, {
                 className: 'keyspanel'
             });
-            
+
             to          = rendy(keysPanel, {
                 className: 'keyspanel hidden'
             });
-            
+
             data        = data.replace(from, to);
         }
-        
+
         left = rendy(Template.panel, {
             side    : 'left',
             content : panel,
@@ -103,76 +103,77 @@
             css     : CSS_URL,
             treeroot    : config("treeroot") || HOME,
             file_editor  : config("file_editor") || "",
-            shell   : config("shell") || ""
+            shell   : config("shell") || "",
+            ood_download   : config("download") || ""
         });
-        
+
         return data;
     }
-    
+
     function readFiles(callback) {
         var filesList,
             paths       = {},
-            
+
             lengthTmpl  = Object.keys(Template).length,
             lenthPath   = TMPL_PATH.length,
             isRead      = lengthTmpl === lenthPath;
-        
+
         if (typeof callback !== 'function')
             throw Error('callback should be function!');
-        
+
         if (isRead) {
             callback();
         } else {
             filesList   = TMPL_PATH.map(function(name) {
                 var path = DIR_FS + name + '.hbs';
-                
+
                 paths[path] = name;
-                
+
                 return path;
             });
-            
+
             files.read(filesList, 'utf8', function(error, files) {
                 if (error)
                     throw error;
                 else
                     Object.keys(files).forEach(function(path) {
                         var name = paths[path];
-                        
+
                         Template[name] = files[path];
                     });
-                
+
                 callback();
             });
         }
     }
-    
+
     /**
      * routing of server queries
      */
     function route(request, response, callback) {
         var name, p, isAuth, isFS, fullPath;
-        
+
         if (!request)
             throw Error('request could not be empty!');
-        
+
         if (!response)
             throw Error('response could not be empty!');
-        
+
         if (typeof callback !== 'function')
             throw Error('callback should be function!');
-        
+
         name    = ponse.getPathName(request);
-        
+
         isAuth  = RegExp('^(/auth|/auth/github)$').test(name);
         isFS    = RegExp('^/$|^' + FS).test(name);
-        
+
         p       = {
             request     : request,
             response    : response,
             gzip        : true,
             name        : name
         };
-        
+
         if (!isAuth && !isFS)
             callback();
         else if (isAuth) {
@@ -181,15 +182,15 @@
         } else if (isFS) {
             name        = name.replace(CloudFunc.FS, '') || '/';
             fullPath    = root(name);
-            
+
             flop.read(fullPath, function(error, dir) {
                 if (dir)
                     dir.path = format.addSlashToEnd(name);
-                
+
                 if (!error)
                     buildIndex(dir, function(error, data) {
                         p.name = PATH_INDEX;
-                        
+
                         if (error)
                             ponse.sendError(error, p);
                         else
@@ -203,34 +204,34 @@
                             p.name = pathReal;
                         else
                             p.name = name;
-                        
+
                         p.gzip = false;
                         ponse.sendFile(p);
                     });
             });
         }
     }
-    
+
     function buildIndex(json, callback) {
         var isMinify = config('minify');
-        
+
         exec.if(!isMinify, function(error, name) {
             fs.readFile(name || PATH_INDEX, 'utf8', function(error, template) {
                 var panel, data;
-                
+
                 if (!error) {
                     panel   = CloudFunc.buildFromJSON({
                         data        : json,
                         prefix      : config('prefix'),
                         template    : Template
                     }),
-                    
+
                     data    = indexProcessing({
                         panel   : panel,
                         data    : template
                     });
                 }
-                
+
                 callback(error, data);
             });
         },  function(callback) {

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -104,7 +104,7 @@
             treeroot    : config("treeroot") || HOME,
             file_editor  : config("file_editor") || "",
             shell   : config("shell") || "",
-            ood_download   : config("download") || ""
+            ood_download   : config("ood_download") || ""
         });
 
         return data;


### PR DESCRIPTION
First commit is a quick fix for the download issue described in https://github.com/OSC/ood-fileexplorer/issues/126

`Content-disposition` is not set yet so things like `*.txt` files are being rendered rather than downloaded. Response headers will need to be set on the system.

This will also need to be expanded to include an optional envvar, and if the system version is not available, fall back to the application's download handler.
