### PR TITLE
Git version

### DIFF
--- a/css/ood_styles.css
+++ b/css/ood_styles.css
@@ -343,3 +343,15 @@ body {
   left: 4px;
   top: 4px;
 }
+
+.fe-version {
+    color: #999;
+    margin: 10px 10px 10px 30px;
+    position: absolute;
+}
+@media (max-width: 982px)
+{
+    .fe-version {
+        display: none;
+    }
+}

--- a/html/index.html
+++ b/html/index.html
@@ -55,8 +55,7 @@
     });
     OOD = {
         file_editor: "{{ file_editor }}",
-        shell: "{{ shell }}",
-        ood_download: "{{ ood_download }}"
+        shell: "{{ shell }}"
     };
 </script>
 <script src="{{ prefix }}/cloudcmd.js"></script>

--- a/html/index.html
+++ b/html/index.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <!-- ood-fileexplorer version: {{ fileexplorer_version }} -->
-
     <meta charset="utf-8">
     <meta name="robots" content="noindex,nofollow">
     <meta name="theme-color" content="rgb(49,123,249)">
@@ -45,6 +43,7 @@
         <label class="bootstrap checkbox-inline"><input type="checkbox" class="bootstrap" id="checkbox-dotfiles" onclick="dotfilesChecked()" value="">Show Dotfiles</label>
         <label class="bootstrap checkbox-inline"><input type="checkbox" class="bootstrap" id="checkbox-ownermode" onclick="ownerModeChecked()" value="">Show Owner/Mode</label>
     </div>
+    <div><span class="fe-version">File Explorer {{ fileexplorer_version }}</span></div>
     <div class="fm">{{ fm }}</div>
 <script src="{{ prefix }}/lib/client/ood_tree.js"></script>
 <script src="{{ prefix }}/lib/client/ood.js"></script>

--- a/html/index.html
+++ b/html/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <!-- ood-fileexplorer version: {{ fileexplorer_version }} -->
+
     <meta charset="utf-8">
     <meta name="robots" content="noindex,nofollow">
     <meta name="theme-color" content="rgb(49,123,249)">

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -104,7 +104,8 @@
             treeroot    : config("treeroot") || HOME,
             file_editor  : config("file_editor") || "",
             shell   : config("shell") || "",
-            ood_download   : config("ood_download") || ""
+            ood_download   : config("ood_download") || "",
+            fileexplorer_version   : config("fileexplorer_version") || ""
         });
 
         return data;

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -104,7 +104,6 @@
             treeroot    : config("treeroot") || HOME,
             file_editor  : config("file_editor") || "",
             shell   : config("shell") || "",
-            ood_download   : config("ood_download") || "",
             fileexplorer_version   : config("fileexplorer_version") || ""
         });
 


### PR DESCRIPTION
In conjunction with https://github.com/OSC/ood-fileexplorer/pull/136 adds the current git tag version to a HTML comment in the rendered page.

Useful for evaluating what version of the app is currently running in production.

Also removed some old code on this branch.