### PR TITLE
add a warning if user attempts to upload a file larger than 2GB

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -54,7 +54,8 @@
     });
     OOD = {
         file_editor: "{{ file_editor }}",
-        shell: "{{ shell }}"
+        shell: "{{ shell }}",
+        upload_max: {{ upload_max }}
     };
 </script>
 <script src="{{ prefix }}/cloudcmd.js"></script>

--- a/lib/client/dom.js
+++ b/lib/client/dom.js
@@ -413,14 +413,16 @@ var CloudCmd, Util, DOM, CloudFunc;
                     load    = function(file, callback) {
                         var uploader,
                             Images      = DOM.Images,
+                            Dialog      = DOM.Dialog,
                             name        = file.name,
                             path        = dir + name,
                             prefixURL   = CloudCmd.PREFIX_URL,
                             FS          = CloudFunc.FS,
                             api         = prefixURL + FS;
 
-                            ++i;
+                        ++i;
 
+                        function uploadfile() {
                             uploader = DOM.load.put(api + path, file);
                             uploader.on('progress', function(count) {
                                 var max     = step(n),
@@ -431,6 +433,21 @@ var CloudCmd, Util, DOM, CloudFunc;
                             });
 
                             uploader.on('end', callback);
+                        }
+
+                        // If the file to be uploaded is over 2GB, warn the user but allow them to proceed.
+                        if (file.size > 2097152000) {
+                            var msg = "The file '" + name + "' is very large (" + parseInt(file.size / 1024 / 1024) + "MB) and you may have " +
+                                "difficulty uploading over HTTP. It is recommended that you use SFTP transfers " +
+                                "instead.\n" +
+                                "Click \"OK\" if you would like to attempt to upload this file anyways."
+
+                            Dialog.confirm  (TITLE, msg, {cancel: false}).then(function(name) {
+                                uploadfile();
+                            });
+                        } else {
+                            uploadfile();
+                        }
                     };
 
                 if (!files) {

--- a/lib/client/dom.js
+++ b/lib/client/dom.js
@@ -436,17 +436,29 @@ var CloudCmd, Util, DOM, CloudFunc;
                         }
 
                         // If the file to be uploaded is over 2GB, warn the user but allow them to proceed.
-                        if (file.size > 2097152000) {
+                        /*  DISABLED: Uncomment this block of code if we just want to warn users if a file is over a certain size.
+                         if (file.size > 2097152000) {
                             var msg = "The file '" + name + "' is very large (" + parseInt(file.size / 1024 / 1024) + "MB) and you may have " +
-                                "difficulty uploading over HTTP. It is recommended that you use SFTP transfers " +
-                                "instead.\n" +
-                                "Click \"OK\" if you would like to attempt to upload this file anyways."
+                                        "difficulty uploading over HTTP. It is recommended that you use SFTP transfers " +
+                                        "instead.\n" +
+                                        "Click \"OK\" if you would like to attempt to upload this file anyways."
 
                             Dialog.confirm  (TITLE, msg, {cancel: false}).then(function(name) {
                                 uploadfile();
                             });
-                        } else {
+                         } else {
                             uploadfile();
+                         }
+                         */
+
+                        // If the file to be uploaded is less than the maximum supported upload size, upload file.
+                        // Otherwise, provide an error message and do not upload.
+                        if (file.size < OOD.upload_max) {
+                            uploadfile();
+                        } else {
+                            var msg = "The file '" + name + "' (" + parseInt(file.size / 1024 / 1024) + "MB) is too large to upload via the web interface. " +
+                                "The maximum upload size is " + parseInt(OOD.upload_max / 1024 / 1024) + "MB. Please use SFTP to transfer this file instead.";
+                            Dialog.alert(TITLE, msg);
                         }
                     };
 

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -104,7 +104,7 @@
             treeroot    : config("treeroot") || HOME,
             file_editor  : config("file_editor") || "",
             shell   : config("shell") || "",
-            upload_max   : config("upload_max") || 0,
+            upload_max   : config("upload_max") || 2097152000,
             fileexplorer_version   : config("fileexplorer_version") || ""
         });
 

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -104,6 +104,7 @@
             treeroot    : config("treeroot") || HOME,
             file_editor  : config("file_editor") || "",
             shell   : config("shell") || "",
+            upload_max   : config("upload_max") || 0,
             fileexplorer_version   : config("fileexplorer_version") || ""
         });
 


### PR DESCRIPTION
Adds a confirmation box warning users when file is large and suggest they use SFTP instead, but does not block them from attempting to upload.

![largefile](https://cloud.githubusercontent.com/assets/2374718/20108703/eeea4954-a5aa-11e6-9b1a-9f61971e91d9.png)
