### PR TITLE
limit size of files uploaded in directories and via drag and drop interface

### DIFF
--- a/lib/client/directory.js
+++ b/lib/client/directory.js
@@ -61,7 +61,17 @@
                 
                 switch(type) {
                 case 'file':
-                    upload = uploadFile(full, data);
+                    // If the file to be uploaded is less than the maximum supported upload size, upload file.
+                    // Otherwise, provide an error message and do not upload.
+                    // See also DOM.uploadFiles() for simialar behavior on dialog uploads
+                    if (data.size < OOD.upload_max) {
+                        upload = uploadFile(full, data);
+                    } else {
+                        var msg = "The file '" + name + "' (" + parseInt(data.size / 1024 / 1024) + "MB) is too large to upload via the web interface. " +
+                            "The maximum upload size is " + parseInt(OOD.upload_max / 1024 / 1024) + "MB. Please use SFTP to transfer this file instead.";
+                        Dialog.alert("Error", msg);
+                        upload = uploadFile(full, null);
+                    }
                     break;
                 
                 case 'directory':

--- a/lib/client/directory.js
+++ b/lib/client/directory.js
@@ -70,7 +70,7 @@
                         var msg = "The file '" + name + "' (" + parseInt(data.size / 1024 / 1024) + "MB) is too large to upload via the web interface. " +
                             "The maximum upload size is " + parseInt(OOD.upload_max / 1024 / 1024) + "MB. Please use SFTP to transfer this file instead.";
                         Dialog.alert("Error", msg);
-                        upload = uploadFile(full, null);
+                        upload = uploadFile("", null);
                     }
                     break;
                 

--- a/lib/client/dom.js
+++ b/lib/client/dom.js
@@ -453,6 +453,7 @@ var CloudCmd, Util, DOM, CloudFunc;
 
                         // If the file to be uploaded is less than the maximum supported upload size, upload file.
                         // Otherwise, provide an error message and do not upload.
+                        // See also Directory.uploader() for simialar behavior on directory uploads
                         if (file.size < OOD.upload_max) {
                             uploadfile();
                         } else {


### PR DESCRIPTION
Add functionality similar to 12e6b0c4710b5d2b274bf0820c5f26bb45e5fb06 for the case of Drag and Drop files.

I don't like the duplication here but it's using a different method to upload the file and I didn't want to recreate everything.