### PR TITLE
Silent delete

### DIFF
--- a/lib/client/operation.js
+++ b/lib/client/operation.js
@@ -302,32 +302,26 @@
             names       = DOM.getFilenames(files),
             n           = names.length;
 
-            // OSC_CUSTOM_CODE Removed this block. If no files selected, don't try to add a file.
-            //          This can potentially call the `..` folder and set names = ['..']
-            //if (!n)
-            //    names   = [Info.name];
+            if (!n)
+                names   = [Info.name];
 
-            // OSC_CUSTOM_CODE if n == 0 don't delete anything
-            if (n) {
-                
-                deleteFn(path + query, names, function(error) {
-                    var Storage     = DOM.Storage,
-                        dirPath     = Info.dirPath,
-                        delCurrent  = DOM.deleteCurrent,
-                        delSelected = DOM.deleteSelected,
-                        getByName   = DOM.getCurrentByName;
+            deleteFn(path + query, names, function(error) {
+                var Storage     = DOM.Storage,
+                    dirPath     = Info.dirPath,
+                    delCurrent  = DOM.deleteCurrent,
+                    delSelected = DOM.deleteSelected,
+                    getByName   = DOM.getCurrentByName;
 
-                    if (!error) {
-                        if (n > 1)
-                            delSelected(files);
-                        else
-                            delCurrent(getByName(name));
+                if (!error) {
+                    if (n > 1)
+                        delSelected(files);
+                    else
+                        delCurrent(getByName(name));
 
-                        Storage.removeMatch(dirPath);
-                        jQuery12('body').trigger("tree_refresh_needed");
-                    }
-                });
-            }
+                    Storage.removeMatch(dirPath);
+                    jQuery12('body').trigger("tree_refresh_needed");
+                }
+            });
         }
 
         /*

--- a/lib/client/operation.js
+++ b/lib/client/operation.js
@@ -272,7 +272,7 @@
                 msg    = msgAsk + msgSel + type + name + '?';
             }
 
-            if (name === '..')
+            if (name === '..' || name == '')
                 Dialog.alert.noFiles(TITLE);
             else
                 Dialog.confirm(TITLE, msg, {cancel: false}).then(function() {


### PR DESCRIPTION
* revert changes from da14a3b8b4ca992853755e78126d5c0b9f8eb964
* modify the `promptDelete` method to show the "No Files" message when filename is empty string.