### PR TITLE
Explicitly mention move functionality (OSC/ood-fileexplorer #144)

### DIFF
--- a/lib/client/dom.js
+++ b/lib/client/dom.js
@@ -1480,7 +1480,7 @@ var CloudCmd, Util, DOM, CloudFunc;
                 if (from === '..')
                     Dialog.alert.noFiles(TITLE);
                 else
-                    Dialog.prompt(TITLE, 'Rename', from, {cancel: false}).then(function(to) {
+                    Dialog.prompt(TITLE, 'Rename or type a full path to move the file.', from, {cancel: false}).then(function(to) {
                         isExist     = !!DOM.getCurrentByName(to);
                         dirPath     = Cmd.getCurrentDirPath();
 

--- a/tmpl/fs/path.hbs
+++ b/tmpl/fs/path.hbs
@@ -5,7 +5,7 @@
 <div class="menu-buttons bootstrap">
     <button type="button" class="icon icon-view btn btn-default btn-sm" onclick="CloudCmd['View'].show()">View</button>
     <button type="button" class="icon icon-edit btn btn-default btn-sm hidden" id="editor-button" onclick="ood_editor()">Edit</button>
-    <button type="button" class="icon icon-rename btn btn-default btn-sm" onclick="DOM.renameCurrent()">Rename</button>
+    <button type="button" class="icon icon-rename btn btn-default btn-sm" onclick="DOM.renameCurrent()">Rename/Move</button>
     <button type="button" class="icon icon-download btn btn-primary btn-sm" onclick="download()">Download</button>
     <button type="button" class="icon icon-copy btn btn-default btn-sm" data-toggle="tooltip"
       title="Copy selected files to File Explorer's 'clipboard'"


### PR DESCRIPTION
Adds text indicating that the rename button can also be used to move a file.

Fixes https://github.com/OSC/ood-fileexplorer/issues/144