### PR TITLE
Set the root tree via parameter

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -34,28 +34,32 @@
     <link rel="prefetch" href="{{ file_editor }}">
 </head>
 <body class="hide-owner-mode">
-    <div class="bootstrap panel-btns">
-        <button type="button" class="bootstrap icon icon-directory btn btn-default btn-sm" onclick="DOM.goToDirectory()">Go To...</button>
-        <button type="button" class="bootstrap icon icon-console btn btn-default btn-sm hidden" id="terminal-button" onclick="terminal()">Open in Terminal</button>
-        <button type="button" class="bootstrap icon icon-new btn btn-default btn-sm" onclick="DOM.promptNewFile()">New File</button>
-        <button type="button" class="bootstrap icon icon-directory btn btn-default btn-sm" onclick="DOM.promptNewDir()">New Dir</button>
-        <button type="button" class="bootstrap icon icon-upload btn btn-default btn-sm" onclick="CloudCmd.Upload.show();">Upload</button>
-        <label class="bootstrap checkbox-inline"><input type="checkbox" class="bootstrap" id="checkbox-dotfiles" onclick="dotfilesChecked()" value="">Show Dotfiles</label>
-        <label class="bootstrap checkbox-inline"><input type="checkbox" class="bootstrap" id="checkbox-ownermode" onclick="ownerModeChecked()" value="">Show Owner/Mode</label>
-    </div>
-    <div><span class="fe-version">File Explorer {{ fileexplorer_version }}</span></div>
-    <div class="fm">{{ fm }}</div>
+<div class="bootstrap panel-btns">
+    <button type="button" class="bootstrap icon icon-directory btn btn-default btn-sm" onclick="DOM.goToDirectory()">Go To...</button>
+    <button type="button" class="bootstrap icon icon-console btn btn-default btn-sm hidden" id="terminal-button" onclick="terminal()">Open in Terminal</button>
+    <button type="button" class="bootstrap icon icon-new btn btn-default btn-sm" onclick="DOM.promptNewFile()">New File</button>
+    <button type="button" class="bootstrap icon icon-directory btn btn-default btn-sm" onclick="DOM.promptNewDir()">New Dir</button>
+    <button type="button" class="bootstrap icon icon-upload btn btn-default btn-sm" onclick="CloudCmd.Upload.show();">Upload</button>
+    <label class="bootstrap checkbox-inline"><input type="checkbox" class="bootstrap" id="checkbox-dotfiles" onclick="dotfilesChecked()" value="">Show Dotfiles</label>
+    <label class="bootstrap checkbox-inline"><input type="checkbox" class="bootstrap" id="checkbox-ownermode" onclick="ownerModeChecked()" value="">Show Owner/Mode</label>
+</div>
+<div><span class="fe-version">File Explorer {{ fileexplorer_version }}</span></div>
+<div class="fm">{{ fm }}</div>
 <script src="{{ prefix }}/lib/client/ood_tree.js"></script>
 <script src="{{ prefix }}/lib/client/ood.js"></script>
 <script>
     // Event handler activates on page load
     jQuery12('body').on('panel_initialized', function(e){
-        initTree("{{ treeroot }}");
+        set_treeroot("{{ treeroot }}");
+        initTree(get_treeroot());
     });
     OOD = {
         file_editor: "{{ file_editor }}",
         shell: "{{ shell }}",
-        upload_max: {{ upload_max }}
+        upload_max: {{ upload_max }},
+        treeroot: "{{ treeroot }}",
+        treeroottitle: "{{ treerootitle }}",
+        home_dir: "{{ home_dir }}"
     };
 </script>
 <script src="{{ prefix }}/cloudcmd.js"></script>

--- a/html/index.html
+++ b/html/index.html
@@ -58,7 +58,7 @@
         shell: "{{ shell }}",
         upload_max: {{ upload_max }},
         treeroot: "{{ treeroot }}",
-        treeroottitle: "{{ treerootitle }}",
+        treeroottitle: "{{ treeroottitle }}",
         home_dir: "{{ home_dir }}"
     };
 </script>

--- a/lib/client/ood_tree.js
+++ b/lib/client/ood_tree.js
@@ -1,59 +1,99 @@
 var initTree = function(treeroot){
-  // var self = this;
-  // not sure how to style yet as icon: "mini-icon directory" works...
-  // but doesn't
-  jQuery12('#directory-tree').jstree({
-      'core' : {
-        'multiple' : false,
-        'data' : {
-          url: function(node){
-            if(node.id == "#")
-              return CloudCmd.PREFIX_URL + "/fs" + treeroot;
-            else
-              return CloudCmd.PREFIX_URL + "/fs" + node.id;
-          },
-          dataFilter: function(data, type){
-            var parsed_data = JSON.parse(data);
-            return JSON.stringify(parsed_data.files.filter(function(arg){
-                // filter out dotfiles and non directories
-                return (! arg.name.startsWith(".")) && arg.size == "dir";
-            }).map(function(arg){
-                //FIXME:
-                // how do we know if it is a leaf node? we do not :-(
-                // solution - we need to have a CUSTOM request that actually
-                // returns whether or not the directory CONTAINS any subdirectories
-                // THUS our own request/response in front of the api request/response
-                // but this works well now...
-                return {text: arg.name, children: true, id: parsed_data.path + arg.name}; // add id or attribute for full path
-            }));
-          }
+
+    // Set the root label and link
+    set_treeroot_label(treeroot);
+    // var self = this;
+    // not sure how to style yet as icon: "mini-icon directory" works...
+    // but doesn't
+    jQuery12('#directory-tree').jstree({
+        'core' : {
+            'multiple' : false,
+            'data' : {
+                url: function(node){
+                    if(node.id == "#")
+                        return CloudCmd.PREFIX_URL + "/fs" + treeroot;
+                    else
+                        return CloudCmd.PREFIX_URL + "/fs" + node.id;
+                },
+                dataFilter: function(data, type){
+                    var parsed_data = JSON.parse(data);
+                    return JSON.stringify(parsed_data.files.filter(function(arg){
+                        // filter out dotfiles and non directories
+                        return (! arg.name.startsWith(".")) && arg.size == "dir";
+                    }).map(function(arg){
+                        //FIXME:
+                        // how do we know if it is a leaf node? we do not :-(
+                        // solution - we need to have a CUSTOM request that actually
+                        // returns whether or not the directory CONTAINS any subdirectories
+                        // THUS our own request/response in front of the api request/response
+                        // but this works well now...
+                        return {text: arg.name, children: true, id: parsed_data.path + arg.name}; // add id or attribute for full path
+                    }));
+                }
+            }
         }
-      }
-  });
+    });
 };
 
+var set_treeroot_label = function(treeroot) {
+    set_treeroot(treeroot);
+
+    var link = document.getElementById("panel-treeroot");
+    var label = document.getElementById("panel-treeroottitle");
+
+    link.href = get_treeroot();
+    label.innerText = get_treeroottitle();
+
+}
+
+var get_treeroot = function(){
+    if (window.name !== "") {
+        return window.name;
+    } else {
+        return OOD.treeroot;
+    }
+
+}
+
+var set_treeroot = function ( pathname ) {
+    if ((pathname !== "") && (pathname !== OOD.home_dir)) {
+        window.name = pathname;
+        OOD.treeroot = pathname;
+    }
+}
+
+var get_treeroottitle = function() {
+    if (window.name !== "") {
+        // TODO trim this if too long
+        return window.name;
+    } else {
+        return "Home Directory";
+    }
+}
+
+
 var load_directory = function(dir){
-  CloudCmd.loadDir({
-    path: dir,
-    isRefresh: false,
-    panel: DOM.getByDataName('js-left')
-  });
+    CloudCmd.loadDir({
+        path: dir,
+        isRefresh: false,
+        panel: DOM.getByDataName('js-left')
+    });
 }
 
 jQuery12('#directory-tree').on('changed.jstree', function(e, data){
-  // NOTE: this will be called when calling refresh on the tree because
-  // refresh does a deselect_all - so we only call load_directory if a directory
-  // is specified
+    // NOTE: this will be called when calling refresh on the tree because
+    // refresh does a deselect_all - so we only call load_directory if a directory
+    // is specified
 
-  //TODO: may have to massage data.node.id
-  // in lib/client/listeners.js this was done:
-  //
-  // link        = link.replace('%%', '%25%');
-  // link        = decodeURI(link);
-  // link        = link.replace(RegExp('^' + prefix + fs), '') || '/';
-  if(data && data.node && data.node.id){
-    load_directory(data.node.id);
-  }
+    //TODO: may have to massage data.node.id
+    // in lib/client/listeners.js this was done:
+    //
+    // link        = link.replace('%%', '%25%');
+    // link        = decodeURI(link);
+    // link        = link.replace(RegExp('^' + prefix + fs), '') || '/';
+    if(data && data.node && data.node.id){
+        load_directory(data.node.id);
+    }
 });
 
 jQuery12('.directory-explorer .home a').click(function(e){
@@ -63,42 +103,42 @@ jQuery12('.directory-explorer .home a').click(function(e){
 });
 
 var updateTreeSelection = function(){
-  var tree = jQuery12('#directory-tree').jstree(true),
-      dir  = DOM.getCurrentDirPath(),
-      dir_without_slash  = dir.slice(0,-1),
-      root = jQuery12('.directory-explorer .home a'),
-      root_path = root.attr('href');
+    var tree = jQuery12('#directory-tree').jstree(true),
+        dir  = DOM.getCurrentDirPath(),
+        dir_without_slash  = dir.slice(0,-1),
+        root = jQuery12('.directory-explorer .home a'),
+        root_path = root.attr('href');
 
-  tree.deselect_all(true);
-  root.parent().removeClass('selected');
+    tree.deselect_all(true);
+    root.parent().removeClass('selected');
 
-  if(dir === root_path || dir_without_slash == root_path){
-    root.parent().addClass("selected");
-  }
-  else{
-    tree.select_node(dir_without_slash, true);
-  }
+    if(dir === root_path || dir_without_slash == root_path){
+        root.parent().addClass("selected");
+    }
+    else{
+        tree.select_node(dir_without_slash, true);
+    }
 };
 
 var refreshTree = function(){
-  var tree = jQuery12('#directory-tree').jstree(true);
+    var tree = jQuery12('#directory-tree').jstree(true);
 
-  // first remove selection so we can call refresh
-  // refresh does a deselect_all and then reselects; and when it does that we
-  // catch that above in the changed.jstree event - which would cause an
-  // unnecessary loading of the panel!
-  // so by deselecting now, jstree won't try to re-select so we can re-select
-  // manually without firing those changed.jstree events in updateTreeSelection
-  tree.deselect_all(true);
+    // first remove selection so we can call refresh
+    // refresh does a deselect_all and then reselects; and when it does that we
+    // catch that above in the changed.jstree event - which would cause an
+    // unnecessary loading of the panel!
+    // so by deselecting now, jstree won't try to re-select so we can re-select
+    // manually without firing those changed.jstree events in updateTreeSelection
+    tree.deselect_all(true);
 
-  // reload tree (and children)
-  // FIXME: hopefully this is fast enough that we don't need to show the loading screen
-  // currently not showing it
-  tree.refresh(true);
+    // reload tree (and children)
+    // FIXME: hopefully this is fast enough that we don't need to show the loading screen
+    // currently not showing it
+    tree.refresh(true);
 }
 
 jQuery12('#directory-tree').on('refresh.jstree', function(){
-  updateTreeSelection();
+    updateTreeSelection();
 });
 
 jQuery12('#directory-tree').on('ready.jstree', function(){

--- a/lib/client/ood_tree.js
+++ b/lib/client/ood_tree.js
@@ -41,7 +41,7 @@ var set_treeroot_label = function(treeroot) {
     var link = document.getElementById("panel-treeroot");
     var label = document.getElementById("panel-treeroottitle");
 
-    link.href = CloudCmd.PREFIX + "/fs" + get_treeroot();
+    link.href = get_treeroot();
     label.innerText = get_treeroottitle();
 
 }
@@ -74,6 +74,10 @@ var get_treeroottitle = function() {
     }
 }
 
+// Sets the `window.name` of the current browser to a json string with properties `treeroot`
+//   and `treeroottitle`. The treeroottitle is the pathname by default, but if the pathname
+//   is more than 20 characters the treeroottitle will be a spliced pathname prefixed with
+//   an ellipsis.
 var set_treeroot = function ( pathname ) {
     if ((pathname !== "") && (pathname !== OOD.home_dir)) {
         var obj = new Object();
@@ -175,4 +179,3 @@ jQuery12('body').on('panel_dir_updated', function(e){
 jQuery12('body').on('tree_refresh_needed', function(e){
     refreshTree();
 });
-

--- a/lib/client/ood_tree.js
+++ b/lib/client/ood_tree.js
@@ -1,5 +1,8 @@
 var initTree = function(treeroot){
 
+    // Trim the trailing slash (if applicable)
+    treeroot = treeroot.replace(/\/$/, "");
+
     // Set the root label and link
     set_treeroot_label(treeroot);
     // var self = this;

--- a/lib/client/ood_tree.js
+++ b/lib/client/ood_tree.js
@@ -46,33 +46,47 @@ var set_treeroot_label = function(treeroot) {
 
 }
 
-var get_treeroot = function(){
+var get_treeroot = function() {
     if (window.name !== "") {
-        return window.name;
+        try {
+            var treeroot_obj = JSON.parse(window.name);
+            return treeroot_obj.treeroot;
+        } catch(error) {
+            // The window.name is not a valid treeroot object
+            return OOD.treeroot;
+        }
     } else {
         return OOD.treeroot;
-    }
-
-}
-
-var set_treeroot = function ( pathname ) {
-    if ((pathname !== "") && (pathname !== OOD.home_dir)) {
-        window.name = pathname;
-        OOD.treeroot = pathname;
     }
 }
 
 var get_treeroottitle = function() {
     if (window.name !== "") {
-        if (window.name.length > 20) {
-            return "..." + window.name.slice(window.name.length - 20);
+        try {
+            var treeroot_obj = JSON.parse(window.name);
+            return treeroot_obj.treeroottitle;
+        } catch(error) {
+            // The window.name is not a valid treeroot object
+            return OOD.treeroottitle;
         }
-        return window.name;
     } else {
-        return "Home Directory";
+        return OOD.treeroottitle;
     }
 }
 
+var set_treeroot = function ( pathname ) {
+    if ((pathname !== "") && (pathname !== OOD.home_dir)) {
+        var obj = new Object();
+        obj.treeroot = pathname;
+        if (pathname.length > 20) {
+            obj.treeroottitle = "..." + window.name.slice(window.name.length - 20);
+        } else {
+            obj.treeroottitle = pathname;
+        }
+        window.name = JSON.stringify(obj);
+        OOD.treeroot = obj.treeroot;
+    }
+}
 
 var load_directory = function(dir){
     CloudCmd.loadDir({

--- a/lib/client/ood_tree.js
+++ b/lib/client/ood_tree.js
@@ -44,7 +44,11 @@ var set_treeroot_label = function(treeroot) {
     var link = document.getElementById("panel-treeroot");
     var label = document.getElementById("panel-treeroottitle");
 
-    link.href = get_treeroot();
+    // Set the href so that the user can right-click open
+    link.href = CloudCmd.PREFIX + "/fs" + get_treeroot();
+    // Set a data-link element so that the click works appropriately.
+    link.dataset.link = get_treeroot();
+    // Set the title of the tree root
     label.innerText = get_treeroottitle();
 
 }
@@ -120,7 +124,7 @@ jQuery12('#directory-tree').on('changed.jstree', function(e, data){
 });
 
 jQuery12('.directory-explorer .home a').click(function(e){
-    load_directory(jQuery12(this).attr('href'))
+    load_directory(jQuery12(this).data('link'))
     e.preventDefault();
     return false;
 });

--- a/lib/client/ood_tree.js
+++ b/lib/client/ood_tree.js
@@ -64,7 +64,9 @@ var set_treeroot = function ( pathname ) {
 
 var get_treeroottitle = function() {
     if (window.name !== "") {
-        // TODO trim this if too long
+        if (window.name.length > 20) {
+            return "..." + window.name.slice(window.name.length - 20);
+        }
         return window.name;
     } else {
         return "Home Directory";

--- a/lib/client/ood_tree.js
+++ b/lib/client/ood_tree.js
@@ -41,7 +41,7 @@ var set_treeroot_label = function(treeroot) {
     var link = document.getElementById("panel-treeroot");
     var label = document.getElementById("panel-treeroottitle");
 
-    link.href = get_treeroot();
+    link.href = CloudCmd.PREFIX + "/fs" + get_treeroot();
     label.innerText = get_treeroottitle();
 
 }

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -85,8 +85,8 @@
         left = rendy(Template.panel, {
             side    : 'left',
             content : panel,
-            treeroot    : config("treeroot") || HOME,
-            treeroottitle : config("treeroottitle") || "Home Directory"
+            treeroot    : process.env.TREEROOT || config("treeroot") || HOME,
+            treeroottitle : process.env.TREEROOT || config("treeroot") || "Home Directory"
         });
 
         /* OSC_CUSTOM_CODE don't render the right panel
@@ -101,14 +101,17 @@
             fm      : left, //  OSC_CUSTOM_CODE remove + right,
             prefix  : Prefix,
             css     : CSS_URL,
-            treeroot     : config("treeroot") || HOME,
-            treeroottitle : config("treeroottitle") || "Home Directory",
-            home_dir     : config("home_dir"),
-            file_editor  : config("file_editor") || "",
-            shell        : config("shell") || "",
-            upload_max   : config("upload_max") || 2097152000,
+            treeroot      : process.env.TREEROOT || config("treeroot") || HOME,
+            treeroottitle : process.env.TREEROOT || config("treeroot") || "Home Directory",
+            home_dir      : config("home_dir"),
+            file_editor   : config("file_editor") || "",
+            shell         : config("shell") || "",
+            upload_max    : config("upload_max") || 2097152000,
             fileexplorer_version   : config("fileexplorer_version") || ""
         });
+
+        // OSC_CUSTOM_CODE Reset treeroot envvar
+        process.env.TREEROOT = "";
 
         return data;
     }

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -86,7 +86,7 @@
             side    : 'left',
             content : panel,
             treeroot    : process.env.TREEROOT || config("treeroot") || HOME,
-            treeroottitle : process.env.TREEROOT || config("treeroot") || "Home Directory"
+            treeroottitle : process.env.TREEROOT || config("treeroottitle") || "Home Directory"
         });
 
         /* OSC_CUSTOM_CODE don't render the right panel
@@ -102,7 +102,7 @@
             prefix  : Prefix,
             css     : CSS_URL,
             treeroot      : process.env.TREEROOT || config("treeroot") || HOME,
-            treeroottitle : process.env.TREEROOT || config("treeroot") || "Home Directory",
+            treeroottitle : process.env.TREEROOT || config("treeroottitle") || "Home Directory",
             home_dir      : config("home_dir"),
             file_editor   : config("file_editor") || "",
             shell         : config("shell") || "",
@@ -111,7 +111,7 @@
         });
 
         // OSC_CUSTOM_CODE Reset treeroot envvar
-        process.env.TREEROOT = "";
+        delete process.env.TREEROOT;
 
         return data;
     }

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -43,9 +43,9 @@
 
         // OSC_CUSTOM_CODE add + "?" + Date.now() to prevent browser caching of css files
         CSS_URL     = require(DIR_JSON + 'css.json')
-                        .map(function(name) {
-                            return 'css/' + name + '.css';
-                        }).join(':') + "?" + Date.now();
+            .map(function(name) {
+                return 'css/' + name + '.css';
+            }).join(':') + "?" + Date.now();
 
     module.exports  = function(params) {
         var p = params || {};
@@ -101,9 +101,11 @@
             fm      : left, //  OSC_CUSTOM_CODE remove + right,
             prefix  : Prefix,
             css     : CSS_URL,
-            treeroot    : config("treeroot") || HOME,
+            treeroot     : config("treeroot") || HOME,
+            treeroottitle : config("treeroottitle") || "Home Directory",
+            home_dir     : config("home_dir"),
             file_editor  : config("file_editor") || "",
-            shell   : config("shell") || "",
+            shell        : config("shell") || "",
             upload_max   : config("upload_max") || 2097152000,
             fileexplorer_version   : config("fileexplorer_version") || ""
         });
@@ -227,16 +229,16 @@
                         template    : Template
                     }),
 
-                    data    = indexProcessing({
-                        panel   : panel,
-                        data    : template
-                    });
+                        data    = indexProcessing({
+                            panel   : panel,
+                            data    : template
+                        });
                 }
 
                 callback(error, data);
             });
         },  function(callback) {
-                minify(PATH_INDEX, 'name', callback);
+            minify(PATH_INDEX, 'name', callback);
         });
     }
 })();

--- a/tmpl/fs/panel.hbs
+++ b/tmpl/fs/panel.hbs
@@ -1,7 +1,7 @@
 <div class="directory-explorer">
-  <div class="home"><a href="{{ treeroot }}">
-    <span class="mini-icon directory"></span> {{ treeroottitle }}</a>
-  </div>
-  <div id="directory-tree"></div>
+    <div class="home"><a id="panel-treeroot" href="{{ treeroot }}">
+        <span class="mini-icon directory"></span> <span id="panel-treeroottitle">{{ treeroottitle }}</span></a>
+    </div>
+    <div id="directory-tree"></div>
 </div>
 <section data-name="js-{{ side }}" class="panel panel-{{ side }}">{{ content }}</section>

--- a/tmpl/fs/panel.hbs
+++ b/tmpl/fs/panel.hbs
@@ -1,5 +1,5 @@
 <div class="directory-explorer">
-    <div class="home"><a id="panel-treeroot" href="{{ treeroot }}">
+    <div class="home"><a id="panel-treeroot" oncontextmenu="return false;" href="{{ treeroot }}">
         <span class="mini-icon directory"></span> <span id="panel-treeroottitle">{{ treeroottitle }}</span></a>
     </div>
     <div id="directory-tree"></div>

--- a/tmpl/fs/panel.hbs
+++ b/tmpl/fs/panel.hbs
@@ -1,5 +1,5 @@
 <div class="directory-explorer">
-    <div class="home"><a id="panel-treeroot" oncontextmenu="return false;" href="{{ treeroot }}">
+    <div class="home"><a id="panel-treeroot" href="{{ treeroot }}">
         <span class="mini-icon directory"></span> <span id="panel-treeroottitle">{{ treeroottitle }}</span></a>
     </div>
     <div id="directory-tree"></div>


### PR DESCRIPTION
Allows for the changing of the root of the file tree when a `treeroot` query parameter is set.

This mechanism:

1) Grabs the query param from the URL if present
2) Sets an environment variable on the process to the URL
3) Renders the process variable into a javascript variable on the client html
4) An onload function on the client side checks for the presence of the variable, and if present
5) sets the `window.name` to the path
6) After the variable is rendered into the client html once, the process variable is wiped to prevent future windows from adopting the name

All-in-all, I'm not happy with this solution, as it seems quite serpentine in the way the data transfers around the app. It also the seems to be fairly brittle in it's reliance on "window.name", which could be set by the client browser elsewhere. I'm not sure of another way that we would be able to persist the custom setting across reloads, but not across browser tabs, however.

To test this, you'll need to 
- switch to the `treeroot` branch of `ood-fileexplorer`, 
- remove the `npm-shrinkwrap.json`, 
- update the `package.json` dependency to 
  `"cloudcmd": "git://github.com/OSC/cloudcmd.git#roottree",`
- and install dependencies `npm i`
